### PR TITLE
Allow input plugins "<gap:" on projects using cordova >= 3.*

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="com.ionicframework.starter" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="com.ionicframework.starter" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:gap="http://phonegap.com/ns/1.0">
     <name>StarterApp</name>
     <description>
         A sample Ionic Framework app using Cordova and AngularJS


### PR DESCRIPTION
Add xmlns tag to allow tag "<gap:" when add plugins to new projects using cordova >= 3.*
